### PR TITLE
Add metadata to specs

### DIFF
--- a/spec/admin/controllers/dashboard/index_spec.rb
+++ b/spec/admin/controllers/dashboard/index_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe Admin::Controllers::Dashboard::Index, type: :action do
   let(:operation) { -> { [] } }
   let(:params) { Hash[] }
 
-  it 'is successful' do
+  it 'is successful', :with_mocks do
     response = action.call(params)
     expect(response[0]).to eq 200
   end
 
-  it 'saves links' do
+  it 'saves links', :with_mocks do
     action.call(params)
     expect(action.links).to eq []
   end

--- a/spec/admin/controllers/links/create_spec.rb
+++ b/spec/admin/controllers/links/create_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Admin::Controllers::Links::Create, type: :action do
   let(:action) { described_class.new(operation: operation) }
   let(:operation) { -> (_) { } }
 
-  context 'when params valid' do
+  context 'when params valid', :with_mocks do
     let(:params) { { link: { url: 'google.com' } } }
 
     it 'calls operation' do
@@ -13,7 +13,7 @@ RSpec.describe Admin::Controllers::Links::Create, type: :action do
     it { expect(action.call(params)).to redirect_to '/admin' }
   end
 
-  context 'when params invalid' do
+  context 'when params invalid', :with_mocks do
     let(:params) { {} }
 
     it 'does not call operation' do

--- a/spec/admin/views/application_layout_spec.rb
+++ b/spec/admin/views/application_layout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::Views::ApplicationLayout, type: :view do
   let(:rendered) { layout.render }
   let(:template) { Hanami::View::Template.new('apps/admin/templates/application.html.slim') }
 
-  it 'contains application name' do
+  it 'contains application name', :with_mocks do
     expect(rendered).to include('Admin')
   end
 end

--- a/spec/admin/views/dashboard/index_spec.rb
+++ b/spec/admin/views/dashboard/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Admin::Views::Dashboard::Index, type: :view do
   let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it 'exposes #format' do
+  it 'exposes #format', :with_mocks do
     expect(view.format).to eq exposures.fetch(:format)
   end
 end

--- a/spec/links/operations/create_spec.rb
+++ b/spec/links/operations/create_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Links::Operations::Create do
 
   subject { operation.call(link: 'google.com') }
 
-  context 'when link exist in db' do
+  context 'when link exist in db', :with_mocks do
     let(:link) { Link.new(id: 1) }
 
     it 'update existed link repository with generated key' do
@@ -14,7 +14,7 @@ RSpec.describe Links::Operations::Create do
     end
   end
 
-  context 'when link not exist in db' do
+  context 'when link not exist in db', :with_mocks do
     let(:link) { nil }
 
     it 'calls repository with generated key' do
@@ -23,7 +23,7 @@ RSpec.describe Links::Operations::Create do
     end
   end
 
-  context 'with real repository' do
+  context 'with real repository', :without_mocks do
     let(:operation) { described_class.new }
 
     after { LinkRepository.new.clear }

--- a/spec/web/controllers/links/show_spec.rb
+++ b/spec/web/controllers/links/show_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe Web::Controllers::Links::Show do
   let(:params) { Hash[id: 1] }
   let(:operation) { ->(_) { entity } }
 
-  context 'when link exist' do 
+  context 'when link exist', :with_mocks do 
     let(:entity) { Link.new(url: 'google.com') }
 
     it { expect(action.call(params)).to redirect_to('google.com') }
   end
 
-  context 'when link does not exist' do
+  context 'when link does not exist', :with_mocks do
     let(:entity) { nil }
 
     it 'returns error message' do
@@ -18,7 +18,7 @@ RSpec.describe Web::Controllers::Links::Show do
     end
   end
 
-  context 'when action calls real repository' do
+  context 'when action calls real repository', :without_mocks do
     let(:action) { described_class.new }
     let(:params) { Hash[id: link.key] }
     let(:link) { link_repo.create(key: '123', url: 'google.com') }

--- a/spec/web/views/application_layout_spec.rb
+++ b/spec/web/views/application_layout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Web::Views::ApplicationLayout, type: :view do
   let(:rendered) { layout.render }
   let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.slim') }
 
-  it 'contains application name' do
+  it 'contains application name', :with_mocks do
     expect(rendered).to include('Web')
   end
 end


### PR DESCRIPTION
This allows you to run unit tests separately from long-running tests.
There are a few commands for that:

`bundle exec rspec --tag with_mocks`
and
`bundle exec rspec --tag without_mocks`